### PR TITLE
Add license-files, correct version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "vcsgraph"
 description = "Graph algorithms for version control systems"
 readme = "README.md"
 requires-python = ">=3.10"
+license-files = ["COPYING.txt"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/vcsgraph/__init__.py
+++ b/vcsgraph/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
     "topo_sort",
 ]
 
-__version__ = (0, 2, 0)
+__version__ = (3, 5, 0)
 
 # Re-export commonly used functions and classes
 from .graph import (


### PR DESCRIPTION
The version specified does not match the tag, and further more, the pypi deployment failed due to a missing license-files directive in pyproject.toml.