### PR TITLE
Add license-files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "vcsgraph"
 description = "Graph algorithms for version control systems"
 readme = "README.md"
 requires-python = ">=3.10"
+license-files = ["COPYING.txt"]
 dynamic = ["version"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The pypi deployment failed due to a missing license-files directive in pyproject.toml.